### PR TITLE
Ensure route collisions don't occur with `admin/controller/batch_action` and `admin/controller/:id` (#show)

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
         prefixless_controller_path = controller_path.delete_prefix('admin/')
 
         scope path: :admin, as: :admin do
-          post "#{prefixless_controller_path}/#{method_name}",
+          post "administrate_batch_actions/#{prefixless_controller_path}/#{method_name}",
             to: "#{controller_path}##{method_name}",
             as: "#{method_name}_#{prefixless_controller_path}"
         end

--- a/spec/routes_spec.rb
+++ b/spec/routes_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Routes', type: :routing do
   it 'has route to the batch action' do
-    expect(admin_dummy_batch_action_dummy_path).to eq('/admin/dummy/dummy_batch_action')
+    expect(admin_dummy_batch_action_dummy_path).to eq('/admin/administrate_batch_actions/dummy/dummy_batch_action')
     expect(post: admin_dummy_batch_action_dummy_path).to route_to(
       controller: 'admin/dummy',
       action: 'dummy_batch_action'
@@ -10,7 +10,7 @@ RSpec.describe 'Routes', type: :routing do
   end
 
   it 'has route to the batch action in a nested namespace' do
-    expect(admin_my_batch_action_nested_namespace_path).to eq('/admin/nested/namespace/my_batch_action')
+    expect(admin_my_batch_action_nested_namespace_path).to eq('/admin/administrate_batch_actions/nested/namespace/my_batch_action')
     expect(post: admin_my_batch_action_nested_namespace_path).to route_to(
       controller: 'admin/nested/namespace',
       action: 'my_batch_action'


### PR DESCRIPTION
# Why

When https://github.com/SourceLabsLLC/administrate_batch_actions/pull/47 was merged it opened the possibility for `admin/controller/action` style url routes to conflict with existing `admin/controller/:id` #show endpoint. This PR uses the gem's name to prefix the route to avoid collisions.

For example

Admin::MyController#some_batch_action => admin/my_controller/some_batch_action
Admin::MyController#show => admin/my_controller/:id

In this case `admin/my_controller/:id` will likely be defined before the dynamically generated batch_action routes

# What

* Append `administrate_batch_actions/` to routes